### PR TITLE
Provide meaningful error message when RM is using gnupg >= 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,13 @@ docker build -t $USER/php-build .
 ```
 
 To use your build, call the `docker run` command above with `$USER/php-build` rather than `dshafik/php-build`
+
+## GnuPG version 2.1
+
+GnuPG >= 2.1 use a key format which is incompatable with earlier versions
+and appears to be incapable of downgrading gpg2.1 keys.
+Meanwhile, Debian 8 happens to ship with GnuPG 1.4,
+so you may need to create a new key.
+
+Check for ~/.gnupg/{pub,sec}ring.gpg to determine if
+you have a GnuPG v1 key available.

--- a/build.sh
+++ b/build.sh
@@ -144,9 +144,15 @@ function check_ssh_key {
 function check_gpg {
 	if [ ! -f "/secure/.gnupg/pubring.gpg" ]
 	then
-		msg_error "GPG Keys Not Found. Did you mount it?"
-		msg_info "Try running docker with:"
-		msg_info "-v\$HOME/.gnupg:/secure/.gnupg"
+		if [ -f "/secure/.gnupg/pubring.kbx" ]
+		then
+			msg_error "GPGv2 pubring found, but not GPGv1"
+			msg_info "Debian 8 only support GPGv1 keys"
+		else
+			msg_error "GPG Keys Not Found. Did you mount it?"
+			msg_info "Try running docker with:"
+			msg_info "-v\$HOME/.gnupg:/secure/.gnupg"
+		fi
 		exit -1
 	fi
 


### PR DESCRIPTION
GPG changed its file format in a non BC way,
but our build container is still fixed to Debian 8
which is on the paleolithic gpg version 1.4 .

Add a note to README.md warning of this,
and a check in build.sh for those who don't read docs.